### PR TITLE
Fix: Update deprecated w_xaxis to xaxis for Matplotlib 3.x compatibility

### DIFF
--- a/src/python_tools/plotting_tools.py
+++ b/src/python_tools/plotting_tools.py
@@ -184,9 +184,9 @@ def plot_reference_frames( frames, args, vectors = [], plots = [], planes = [] )
 		ax.set_axis_off()
 
 	if _args[ 'axes_no_fill' ]:
-		ax.w_xaxis.pane.fill = False
-		ax.w_yaxis.pane.fill = False
-		ax.w_zaxis.pane.fill = False
+		ax.xaxis.pane.fill = False
+		ax.yaxis.pane.fill = False
+		ax.zaxis.pane.fill = False
 
 	if _args[ 'azimuth' ] is not None:
 		ax.view_init( elev = _args[ 'elevation' ],
@@ -316,9 +316,9 @@ def plot_orbits( rs, args, vectors = [] ):
 					  azim = _args[ 'azimuth'   ] )
 	
 	if _args[ 'axes_no_fill' ]:
-		ax.w_xaxis.pane.fill = False
-		ax.w_yaxis.pane.fill = False
-		ax.w_zaxis.pane.fill = False		
+		ax.xaxis.pane.fill = False
+		ax.yaxis.pane.fill = False
+		ax.zaxis.pane.fill = False		
 
 	if _args[ 'hide_axes' ]:
 		ax.set_axis_off()
@@ -953,9 +953,9 @@ def plot_cr3bp_3d( mu, rs, args, vectors = [] ):
 					  azim = _args[ 'azimuth'   ] )
 
 	if _args[ 'axes_no_fill' ]:
-		ax.w_xaxis.pane.fill = False
-		ax.w_yaxis.pane.fill = False
-		ax.w_zaxis.pane.fill = False
+		ax.xaxis.pane.fill = False
+		ax.yaxis.pane.fill = False
+		ax.zaxis.pane.fill = False
 
 	if _args[ 'hide_axes' ]:
 		ax.set_axis_off()
@@ -1048,4 +1048,5 @@ def plot_pseudopotential_contours( system, args ):
 		plt.show()
 
 	plt.close()
+
 


### PR DESCRIPTION
In recent versions of Matplotlib, the w_xaxis attribute for 3D axes has been removed. This causes an AttributeError when running the script.

Replaced ax.w_xaxis with ax.xaxis
Replaced ax.w_yaxis with ax.yaxis
Replaced ax.w_zaxis with ax.zaxis
